### PR TITLE
Update requirements.txt - Remove pycrypto from requirements.txt

### DIFF
--- a/lesson_4/requirements.txt
+++ b/lesson_4/requirements.txt
@@ -145,7 +145,6 @@ py==1.8.1
 pycodestyle==2.5.0
 pycosat==0.6.3
 pycparser==2.19
-pycrypto==2.6.1
 pycurl==7.43.0.5
 pydocstyle==4.0.1
 pyflakes==2.1.1


### PR DESCRIPTION
Remove pycrypto from requirements.txt
CVE-2013-7459
Vulnerable versions: <= 2.6.1
Heap-based buffer overflow in the ALGnew function in block_templace.c in Python Cryptography Toolkit (aka pycrypto) allows remote attackers to execute arbitrary code as demonstrated by a crafted iv parameter to cryptmsg.py.
CVE-2018-6594
Vulnerable versions: <= 2.6.1
lib/Crypto/PublicKey/ElGamal.py in PyCrypto through 2.6.1 generates weak ElGamal key parameters, which allows attackers to obtain sensitive information by reading ciphertext data (i.e., it does not have semantic security in face of a ciphertext-only attack). The Decisional Diffie-Hellman (DDH) assumption does not hold for PyCrypto's ElGamal implementation.